### PR TITLE
Fix security vulnerabilities and code bugs

### DIFF
--- a/commands/mod/ping.js
+++ b/commands/mod/ping.js
@@ -1,11 +1,4 @@
-//Weird Fix, May be completely wrong, fix need be
-
 const Commando = require('discord.js-commando');
-const Discord = require('discord.js');
-
-const client = new Discord.Client();
-
-const { token } = require('../../config.json');
 
 class Ping extends Commando.Command{
 	constructor(client){
@@ -18,10 +11,8 @@ class Ping extends Commando.Command{
 	}
 
 	async run (message, args){
-		message.channel.send(`${client.user.username} is Online & Ready To Use @ ` + `${client.ping} ms`);
+		message.channel.send(`${this.client.user.username} is Online & Ready To Use @ ` + `${this.client.ping} ms`);
 	}
 }
 
 module.exports = Ping;
-
-client.login(token);

--- a/commands/voice/play.js
+++ b/commands/voice/play.js
@@ -15,14 +15,14 @@ class Play extends Discord.Command{
 		if(message.member.voiceChannel){
 			if(!message.guild.voiceConnection){
 				if(!servers[message.guild.id]){
-					servers[message.message.guild.id] = { queue: [] }
+					servers[message.guild.id] = { queue: [] }
 				}
 				message.member.voiceChannel.join()
 				.then(connection => {
 					var server = servers[message.guild.id];
 					// message.reply('Playing: ' + ytdl.getInfo(URL));
 					server.queue.push(args);
-					URL(connection, message);
+					playStream(connection, message);
 				})
 			}
 		} else{
@@ -33,17 +33,17 @@ class Play extends Discord.Command{
 
 module.exports = Play;
 
-/*function URL(connection, message){
+function playStream(connection, message){
 	var server = servers[message.guild.id]
-	server.dispatcher = connection.playStream(YTDL(server.queue[0], { 
-		filter: 'audioonly' 
+	server.dispatcher = connection.playStream(YTDL(server.queue[0], {
+		filter: 'audioonly'
 	}));
 	server.queue.shift();
 	server.dispatcher.on('end', function(){
 		if(server.queue[0]){
-			URL(connection, message);
+			playStream(connection, message);
 		} else{
 			connection.disconnect();
 		}
 	});
-}*/
+}

--- a/package.json
+++ b/package.json
@@ -13,14 +13,11 @@
     "discord.js": "^11.5.0",
     "discord.js-commando": "^0.10.0",
     "ffmpeg": "^0.0.4",
-    "ffmpeg-binaries": "^4.0.0",
     "node-opus": "^0.3.1",
     "sqlite": "^3.0.3",
     "ytdl-core": "^0.29.1"
   },
-  "devDependencies": {
-    "hoek": "^6.1.2"
-  },
+  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/JakeWard98/Ky8er-Bot.git"


### PR DESCRIPTION
## Summary
- **ping.js**: Removed rogue `Discord.Client` instantiation and `client.login(token)` that created a second bot connection on every module load. Now uses `this.client` from the Commando constructor.
- **play.js**: Fixed `message.message.guild.id` typo → `message.guild.id`, and uncommented/renamed the `URL()` function to `playStream()` to fix a `ReferenceError` at runtime.
- **package.json**: Removed unused `ffmpeg-binaries` dependency (introduced critical/high `lzma-native` vulnerability chain) and `hoek` devDependency (prototype pollution, no fix available, unused in code).
- Reduces npm audit from **26 vulnerabilities (3 critical, 15 high)** to **5 high** (remaining are embedded in the `discord.js-commando` → `sqlite` → `sqlite3` → `tar` chain, only fixable via a full framework migration to discord.js v14).

## Test plan
- [ ] Verify `ping` command works and shows correct bot username and ping
- [ ] Verify `play` command joins voice channel and plays audio without errors
- [ ] Run `npm audit` and confirm vulnerability count is reduced to 5

https://claude.ai/code/session_01EnDD45d2Qrn47X8svaz18M