### PR TITLE
fix: stop npm test from always failing with exit 1

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,23 +76,6 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@4f3212b61783c3c68e8309a0f18842c009827cc9  # v3.28.14
       with:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "First Bot",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"No tests configured\" && exit 0",
     "start": "node ."
   },
   "author": "Ky8er",


### PR DESCRIPTION
## Summary

- The default npm placeholder test script (`exit 1`) caused `npm test` to constantly fail as a check
- Replaced with a no-op that exits 0 with a "No tests configured" message
- Removed the CodeQL "Run manual build steps" template block which contained a hardcoded `exit 1` (was skipped by `build-mode: none` but a latent trap)

## Test plan

- [x] Run `npm test` locally — exits 0 with "No tests configured"
- [x] Verify only `codeql.yml` exists as a CI workflow and it does not invoke `npm test`
- [ ] Confirm CodeQL workflow passes on push to master after merge

https://claude.ai/code/session_01KKX7WuMQ51wB4RSoQqkYa1