### PR TITLE
chore(security): 2026-04-27 dependency re-audit + SECURITY.md / CHANGELOG.md / .gitignore + fix unresolvable CodeQL action SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -65,7 +65,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@4f3212b61783c3c68e8309a0f18842c009827cc9  # v3.28.14
+      uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -77,6 +77,6 @@ jobs:
         # queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@4f3212b61783c3c68e8309a0f18842c009827cc9  # v3.28.14
+      uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3.35.2
       with:
         category: "/language:${{matrix.language}}"

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ jspm_packages/
 .npm
 .eslintcache
 .node_repl_history
+*.tsbuildinfo
+.cache/
+.parcel-cache/
 
 # Packaging
 *.tgz
@@ -57,4 +60,5 @@ Thumbs.db
 config.json
 temp/
 settings.sqlite3
+obsolete_code.js
 obsolote_code.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Security
+- **2026-04-27 dependency re-audit.** Manual cross-check of every package
+  pinned in `package-lock.json` against the GitHub Advisory Database
+  returned **0 known vulnerabilities** at Critical/High/Moderate/Low.
+  Notable transitive deps confirmed already on patched versions:
+  - `undici` 6.24.1 / 7.24.8 — patched against CVE-2026-1526 (WebSocket
+    permessage-deflate memory exhaustion, High), CVE-2026-1527 (CRLF
+    injection via `client.request()` upgrade option, Medium), and
+    CVE-2026-1528 (WebSocket 64-bit length parser overflow, High). All
+    three were fixed in `undici` 6.24.0 / 7.24.0.
+  - `ws` 8.20.0 — patched against CVE-2024-37890 (DoS via excessive
+    request headers, Moderate). Fix landed in 8.17.1.
+  - `tough-cookie` 5.1.2 — not affected by the historic prototype
+    pollution issue CVE-2023-26136 (which only impacted `<4.1.3`).
+  - `lodash` 4.18.1 — current latest, no open advisories.
+  - `discord.js` 14.26.3, `@discordjs/voice` 0.19.2,
+    `@distube/ytdl-core` 4.16.12, `dotenv` 16.6.1 — no open advisories.
+
+  No code or dependency-version changes were required by this audit.
+
+### Added
+- `SECURITY.md` — supported versions, private disclosure process, threat
+  model, operational recommendations. The README already pointed at
+  GitHub's private vulnerability reporting, but the policy document
+  itself was missing.
+- `CHANGELOG.md` — this file.
+
+### Changed
+- `README.md`: link to `SECURITY.md` and `CHANGELOG.md`; clarify that
+  `./setup.sh` runs `npm audit` on every invocation.
+- `.gitignore`: fix typo `obsolote_code.js` → `obsolete_code.js`. The
+  old line is kept so any local file already named with the typo stays
+  ignored. Also added `*.tsbuildinfo`, `.cache/`, `.parcel-cache/` for
+  common JS tooling caches.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ practice code.
 
 ## Requirements
 
-- Node.js **>= 18**
+- Node.js **>= 18** (>= 20 recommended for `@distube/ytdl-core`)
 - A Discord bot token (see
   [Discord Developer Portal](https://discord.com/developers/applications))
 - **Message Content Intent** enabled under *Bot > Privileged Gateway Intents*
@@ -17,7 +17,8 @@ practice code.
 ```
 
 `setup.sh` checks your Node.js version, runs `npm install`, copies
-`.env.example` → `.env` on first run, and runs `npm audit`.
+`.env.example` → `.env` on first run, and runs `npm audit` so any new
+advisories surface immediately.
 
 Then edit `.env` and set your bot token:
 
@@ -76,15 +77,19 @@ Direct runtime deps (kept minimal):
 - [`opusscript`](https://www.npmjs.com/package/opusscript) (audio encoder)
 - [`dotenv`](https://www.npmjs.com/package/dotenv)
 
+Last manual CVE re-audit: **2026-04-27** — see [`CHANGELOG.md`](./CHANGELOG.md)
+for the audit notes. `npm audit` is also run automatically by `setup.sh`.
+
 ## Security
 
-- Never commit your `.env` — it contains your bot token. `.env` is already in
-  `.gitignore`.
+- Never commit your `.env` — it contains your bot token. `.env` is already
+  in `.gitignore`.
 - Rotate the token in the Discord Developer Portal if it ever leaks.
 - Dependency audit status is checked on every `setup.sh` run and by
   [CodeQL](./.github/workflows/codeql.yml) on push/PR to `master`.
 
-Report a vulnerability privately via
+Full security policy, threat model and disclosure process: see
+[`SECURITY.md`](./SECURITY.md). Report a vulnerability privately via
 [GitHub's private vulnerability reporting](https://github.com/JakeWard98/Ky8er-Bot/security/advisories/new).
 
 ## Planned

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security Policy
+
+## Supported Versions
+
+Ky8er-Bot is a small learning project on a rolling-release basis. Security
+fixes land on `master` and are picked up by anyone who pulls and re-runs
+`./setup.sh` (which re-runs `npm install` and `npm audit`).
+
+| Version          | Supported          |
+|------------------|--------------------|
+| `master` (HEAD)  | :white_check_mark: |
+| Older commits    | :x:                |
+
+## Reporting a Vulnerability
+
+Please **do not** report security issues in public GitHub issues.
+
+Use GitHub's private vulnerability reporting:
+
+1. Go to the [Security tab](https://github.com/JakeWard98/Ky8er-Bot/security)
+   on the repository.
+2. Click **Report a vulnerability**.
+3. Provide reproduction steps, affected commit SHA, and impact.
+
+As a hobby project, response times are best-effort but I will aim to
+acknowledge within 7 days.
+
+## Threat Model
+
+Ky8er-Bot is a Discord bot intended to run on a single trusted host with a
+single bot token. It is **not** designed to be multi-tenant or to handle
+untrusted operators.
+
+### What Ky8er-Bot defends against
+
+- **Token leakage to source control.** `.env` is in `.gitignore`. Only
+  `.env.example` (with placeholder values) is tracked.
+- **Unhandled command errors crashing the process.** A `try/catch` around
+  `command.execute()` and a top-level `unhandledRejection` handler keep
+  the bot alive and log the error message (not the full stack with
+  potentially sensitive data) to the console.
+- **Bot replying to its own messages.** The `messageCreate` handler bails
+  out on `message.author.bot`.
+
+### What Ky8er-Bot does **not** defend against
+
+- **A leaked bot token.** Anyone holding the token can fully impersonate
+  the bot. Rotate immediately in the Discord Developer Portal if it
+  leaks.
+- **A malicious server admin.** Mod commands are gated by Discord
+  permissions on the calling user; if you grant mod rights to a hostile
+  user, they get mod-level commands.
+- **Arbitrary YouTube content from `^play`.** `@distube/ytdl-core`
+  fetches and decodes whatever URL is passed. Audio is sent into the
+  voice channel as-is. Don't run the bot on a host where loud audio is
+  itself a problem.
+- **DoS via spammed commands.** No per-user rate limiting is
+  implemented; rely on Discord's own rate limits.
+
+## Operational recommendations
+
+- Keep your Node.js runtime on an LTS release (`>=18`, currently `>=20`
+  recommended for `@distube/ytdl-core`).
+- Re-run `./setup.sh` periodically — it runs `npm install` and
+  `npm audit` so you'll see new advisories as they're published.
+- Don't commit `.env`, `config.json`, or `settings.sqlite3` (already in
+  `.gitignore`).
+- If you fork the bot, regenerate the token on the Developer Portal
+  before running anywhere shared.


### PR DESCRIPTION
## Summary

Manual CVE re-audit on **2026-04-27** of every package pinned in `package-lock.json` against the GitHub Advisory Database. **0 known vulnerabilities** found at Critical / High / Moderate / Low — no dependency-version changes required.

This PR is housekeeping plus one CI fix:

- Add `SECURITY.md` (the README already pointed at GitHub's private vulnerability reporting, but the policy file itself was missing).
- Add `CHANGELOG.md` to track future security work.
- Fix typo in `.gitignore` (`obsolote_code.js` → `obsolete_code.js`); old line kept for back-compat with any existing local file using the typo. Also added `*.tsbuildinfo`, `.cache/`, `.parcel-cache/` for common JS tooling caches.
- README: link to `SECURITY.md` and `CHANGELOG.md`, clarify that `./setup.sh` runs `npm audit`.
- **CI fix (lands on master via this PR):** bump `github/codeql-action/init` and `…/analyze` from the dead SHA `4f3212b6…` (commented `v3.28.14`, returns 404 on `github/codeql-action`) to `ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a` (`v3.35.2`, released 2026-04-15). Master's recent runs were green only because GitHub Actions was resolving the dead SHA from its action cache; new PR runs hit the live API and failed in `Set up job` with `Unable to resolve action github/codeql-action/init@4f3212b…`. SHA-pinning style preserved.

## Audit findings (transitive deps already on patched versions)

| Package | Installed | Notes |
|---|---|---|
| `undici` | 6.24.1 / 7.24.8 | Patched against **CVE-2026-1526** (WebSocket permessage-deflate memory exhaustion, High), **CVE-2026-1527** (CRLF injection via `client.request()` upgrade option, Medium) and **CVE-2026-1528** (WebSocket 64-bit length parser overflow, High). All three were fixed in 6.24.0 / 7.24.0. |
| `ws` | 8.20.0 | Patched against CVE-2024-37890 (DoS via excessive request headers); fix landed in 8.17.1. |
| `tough-cookie` | 5.1.2 | Not affected by the historic prototype-pollution issue CVE-2023-26136 (which only impacted `<4.1.3`). |
| `lodash` | 4.18.1 | Current latest, no open advisories. |
| `discord.js` | 14.26.3 | No open advisories. |
| `@discordjs/voice` | 0.19.2 | No open advisories. |
| `@distube/ytdl-core` | 4.16.12 | No open advisories. |
| `dotenv` | 16.6.1 | No open advisories. |

## Test plan

- [ ] CodeQL workflow on this PR finishes green (was failing pre-fix on the dead SHA).
- [ ] `./setup.sh` still runs cleanly (Node version check, `npm install`, `.env` copy, `npm audit`).
- [ ] `npm start` starts the bot and connects to Discord.
- [ ] `^help`, `^hello`, `^ping` still respond.
- [ ] `git status` after a fresh checkout does not show any of the new `.gitignore` entries as untracked even when their files exist locally.