### PR TITLE
docs(security): record 2026-05-04 dependency re-audit (clean)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-05-04 dependency re-audit.** Manual GHSA / NVD cross-check
+  of every package pinned in `package-lock.json` returned **0 known
+  vulnerabilities** at Critical/High/Moderate/Low. Two new `undici`
+  advisories were published in the week since the 2026-04-27 audit;
+  the pinned transitive versions are already on patched releases:
+  - **CVE-2026-22036** — `undici` unbounded decompression chain on
+    the Node.js Fetch API via `Content-Encoding` (DoS, High). Fixed
+    in `undici` 6.23.0 / 7.18.2. Lockfile pins **6.24.1** (via
+    `discord.js` / `@discordjs/rest`) and **7.24.8** (via
+    `@distube/ytdl-core`) — both above the patched releases.
+  - **CVE-2026-2581** — `undici` `DeduplicationHandler` unbounded
+    memory consumption via response buffering (DoS, Moderate). Fixed
+    in `undici` 7.24.0; only the 7.x branch is affected. Lockfile
+    pins `undici` **7.24.8** — above the patched release.
+  Direct deps (`discord.js 14.26.3`, `@discordjs/voice 0.19.2`,
+  `@distube/ytdl-core 4.16.12`, `dotenv 16.6.1`, `opusscript 0.1.1`)
+  also returned no new advisories. Other transitive deps confirmed
+  still clean: `ws 8.20.0`, `tough-cookie 5.1.2`, `lodash 4.18.1`.
+  No code or dependency-version changes required.
 - **2026-04-27 dependency re-audit.** Manual cross-check of every package
   pinned in `package-lock.json` against the GitHub Advisory Database
   returned **0 known vulnerabilities** at Critical/High/Moderate/Low.
@@ -36,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `README.md`: link to `SECURITY.md` and `CHANGELOG.md`; clarify that
-  `./setup.sh` runs `npm audit` on every invocation.
+  `./setup.sh` runs `npm audit` on every invocation. Audit-date line
+  bumped to **2026-05-04** to match the latest re-audit entry above.
 - `.gitignore`: fix typo `obsolote_code.js` → `obsolete_code.js`. The
   old line is kept so any local file already named with the typo stays
   ignored. Also added `*.tsbuildinfo`, `.cache/`, `.parcel-cache/` for

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Direct runtime deps (kept minimal):
 - [`opusscript`](https://www.npmjs.com/package/opusscript) (audio encoder)
 - [`dotenv`](https://www.npmjs.com/package/dotenv)
 
-Last manual CVE re-audit: **2026-04-27** — see [`CHANGELOG.md`](./CHANGELOG.md)
+Last manual CVE re-audit: **2026-05-04** — see [`CHANGELOG.md`](./CHANGELOG.md)
 for the audit notes. `npm audit` is also run automatically by `setup.sh`.
 
 ## Security


### PR DESCRIPTION
## Summary

Routine weekly security re-audit of the pinned npm dependencies. **No CVE fixes are required** — every package pinned in `package-lock.json` returned **0 known vulnerabilities** at Critical/High/Moderate/Low. Two new `undici` advisories landed in the past week, but the lockfile already pins versions above the patched releases.

This PR refreshes `CHANGELOG.md` with the new audit entry and bumps the "Last manual CVE re-audit" date in `README.md` to match. No code, dependency-version, or `.gitignore` changes.

## Manual CVE check (2026-05-04)

### New advisories since the 2026-04-27 audit

| CVE | Package | Severity | Fixed in | Lockfile pins | Status |
|---|---|---|---|---|---|
| CVE-2026-22036 | `undici` | High (DoS via unbounded decompression chain on Fetch API) | 6.23.0 / 7.18.2 | 6.24.1, 7.24.8 | **Patched** |
| CVE-2026-2581 | `undici` | Moderate (DoS via `DeduplicationHandler` memory consumption) | 7.24.0 (only 7.x affected) | 7.24.8 | **Patched** |

### Direct deps

| Dep | Version | Status |
|---|---|---|
| `discord.js` | 14.26.3 | Clean |
| `@discordjs/voice` | 0.19.2 | Clean |
| `@distube/ytdl-core` | 4.16.12 | Clean |
| `dotenv` | 16.6.1 | Clean |
| `opusscript` | 0.1.1 | Clean |

### Other transitive deps re-confirmed clean

`ws 8.20.0`, `tough-cookie 5.1.2`, `lodash 4.18.1`.

## GitHub vulnerability report

- No open security issues, no Dependabot alerts visible via the issues API.
- The two open issues (#6, #9) are non-security feature/bug items.

## Test plan

- [x] CHANGELOG and README render correctly in GitHub markdown preview.
- [x] Audit-date references in README and CHANGELOG agree (both 2026-05-04).
- [ ] Optionally re-run `npm audit` locally to corroborate the manual check.

https://claude.ai/code/session_015nMmzeqxFzxtV6DR3pFg4w


---
_Generated by [Claude Code](https://claude.ai/code/session_015nMmzeqxFzxtV6DR3pFg4w)_