### PR TITLE
security: 2026-05-11 dependency re-audit (clean)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-05-11 dependency re-audit.** Manual GHSA / NVD cross-check
+  of every package pinned in `package-lock.json` returned **0 known
+  vulnerabilities** at Critical/High/Moderate/Low. No new advisories
+  affecting any pinned dep have been published in the week since the
+  2026-05-04 re-audit. Previously-patched transitive deps confirmed
+  still on safe versions:
+  - `undici` 6.24.1 (via `discord.js` / `@discordjs/rest`) and 7.24.8
+    (via `@distube/ytdl-core`) — both above the patched releases for
+    the March 2026 cluster (CVE-2026-1526, CVE-2026-1527,
+    CVE-2026-1528) and the April 2026 entries (CVE-2026-22036
+    unbounded decompression chain, fixed in 6.23.0 / 7.18.2; and
+    CVE-2026-2581 `DeduplicationHandler` memory exhaustion, fixed in
+    7.24.0).
+  - `ws` 8.20.0 — above 8.17.1 (CVE-2024-37890 DoS via excessive
+    request headers, Moderate).
+  - `tough-cookie` 5.1.2 — not affected by CVE-2023-26136 (only
+    impacts `<4.1.3`).
+  - `lodash` 4.18.1 — current latest, no open advisories.
+  Direct deps (`discord.js 14.26.3`, `@discordjs/voice 0.19.2`,
+  `@distube/ytdl-core 4.16.12`, `dotenv 16.6.1`, `opusscript 0.1.1`)
+  also returned no new advisories. No code or dependency-version
+  changes required.
 - **2026-05-04 dependency re-audit.** Manual GHSA / NVD cross-check
   of every package pinned in `package-lock.json` returned **0 known
   vulnerabilities** at Critical/High/Moderate/Low. Two new `undici`
@@ -56,7 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `README.md`: link to `SECURITY.md` and `CHANGELOG.md`; clarify that
   `./setup.sh` runs `npm audit` on every invocation. Audit-date line
-  bumped to **2026-05-04** to match the latest re-audit entry above.
+  bumped to **2026-05-11** to match the latest re-audit entry above.
 - `.gitignore`: fix typo `obsolote_code.js` → `obsolete_code.js`. The
   old line is kept so any local file already named with the typo stays
   ignored. Also added `*.tsbuildinfo`, `.cache/`, `.parcel-cache/` for

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Direct runtime deps (kept minimal):
 - [`opusscript`](https://www.npmjs.com/package/opusscript) (audio encoder)
 - [`dotenv`](https://www.npmjs.com/package/dotenv)
 
-Last manual CVE re-audit: **2026-05-04** — see [`CHANGELOG.md`](./CHANGELOG.md)
+Last manual CVE re-audit: **2026-05-11** — see [`CHANGELOG.md`](./CHANGELOG.md)
 for the audit notes. `npm audit` is also run automatically by `setup.sh`.
 
 ## Security


### PR DESCRIPTION
## Summary

Records the **2026-05-11** weekly manual dependency re-audit (clean).

### Vulnerability check

- **GitHub issues / vulnerability reports:** the two open issues
  (#6 `^dc` voice-channel guard, #9 queue) are unrelated functional
  bugs — no open vulnerability issues or security advisories.
- **`package-lock.json` re-checked against GHSA + NVD:** **0 known
  vulnerabilities** at Critical / High / Moderate / Low.
- No new advisories affecting any pinned dep have been published in
  the week since the 2026-05-04 re-audit.

### Transitive deps still on safe versions

| Package | Locked | Patch required | Source CVE(s) |
|---------|--------|---------------|---------------|
| `undici` | 6.24.1 (discord.js) / 7.24.8 (ytdl-core) | 6.23.0+ / 7.18.2+ / 7.24.0+ | CVE-2026-1526, -1527, -1528, -22036, -2581 |
| `ws` | 8.20.0 | 8.17.1+ | CVE-2024-37890 |
| `tough-cookie` | 5.1.2 | n/a (≥4.1.3 unaffected) | CVE-2023-26136 |
| `lodash` | 4.18.1 | n/a | none open |

Direct deps (`discord.js 14.26.3`, `@discordjs/voice 0.19.2`,
`@distube/ytdl-core 4.16.12`, `dotenv 16.6.1`, `opusscript 0.1.1`)
also returned no new advisories.

### Changes in this PR

- `CHANGELOG.md`: prepend 2026-05-11 audit entry under
  `[Unreleased] > Security`.
- `README.md`: bump the *Last manual CVE re-audit* date from
  `2026-05-04` → `2026-05-11`.

No `package.json` / `package-lock.json` changes — versions are already
on the latest patched releases. `.gitignore` already cleaned up in the
previous audit cycle; no further changes needed.

## Test plan

- [x] `package.json` / `package-lock.json` unchanged → `setup.sh`
  (`npm install` + `npm audit`) still passes.
- [x] `CHANGELOG.md` renders on GitHub (new entry at the top of the
  Security section).
- [x] `README.md` audit-date matches `CHANGELOG.md` top entry.
- [ ] Optional: run `npm audit --omit=dev` locally to reproduce the
  clean result.

https://claude.ai/code/session_01PyCdScY1MS1KbCcqfNVQX6

---
_Generated by [Claude Code](https://claude.ai/code/session_01PyCdScY1MS1KbCcqfNVQX6)_