### PR TITLE
fix(deps): bump ws to 8.21.0 to close GHSA-58qx-3vcg-4xpx (Moderate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-05-25 dependency re-audit — one new advisory fixed.** `npm audit`
+  against the current `package-lock.json` flagged a single new **Moderate**
+  advisory that post-dates the previous (clean) re-audits:
+  - **GHSA-58qx-3vcg-4xpx** — `ws`: uninitialised memory disclosure
+    (CWE-908, CVSS 4.4 Moderate). Affects `ws >=8.0.0 <8.20.1`. The
+    lockfile previously pinned `ws 8.20.0` (hoisted, shared by
+    `@discordjs/voice` → `ws ^8.19.0` and `discord.js` →
+    `@discordjs/ws` → `ws ^8.17.0`). Bumped the locked `ws` to
+    **8.21.0** via `npm audit fix`; both parent ranges already
+    permitted it, so no `package.json` change was needed.
+  After the bump, `npm audit` reports **0 vulnerabilities** across all
+  66 resolved packages. All other direct deps
+  (`discord.js 14.26.3`, `@discordjs/voice 0.19.2`,
+  `@distube/ytdl-core 4.16.12`, `dotenv 16.6.1`, `opusscript 0.1.1`)
+  and notable transitives (`undici 6.24.1` / `7.24.8`,
+  `tough-cookie 5.1.2`, `lodash 4.18.1`) remain clean.
 - **2026-05-04 dependency re-audit.** Manual GHSA / NVD cross-check
   of every package pinned in `package-lock.json` returned **0 known
   vulnerabilities** at Critical/High/Moderate/Low. Two new `undici`

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Direct runtime deps (kept minimal):
 - [`opusscript`](https://www.npmjs.com/package/opusscript) (audio encoder)
 - [`dotenv`](https://www.npmjs.com/package/dotenv)
 
-Last manual CVE re-audit: **2026-05-04** — see [`CHANGELOG.md`](./CHANGELOG.md)
+Last manual CVE re-audit: **2026-05-25** — see [`CHANGELOG.md`](./CHANGELOG.md)
 for the audit notes. `npm audit` is also run automatically by `setup.sh`.
 
 ## Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -863,9 +863,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary

The **2026-05-25** dependency re-audit surfaced **one new advisory** that
post-dates the previous (clean) re-audits — and this PR fixes it.

- **GHSA-58qx-3vcg-4xpx** — `ws`: uninitialised memory disclosure
  (CWE-908, **CVSS 4.4 Moderate**). Affects `ws >=8.0.0 <8.20.1`.
- The lockfile pinned `ws 8.20.0` — a hoisted transitive dep shared by
  `@discordjs/voice` (`ws ^8.19.0`) and `discord.js` → `@discordjs/ws`
  (`ws ^8.17.0`).
- Fixed via `npm audit fix --package-lock-only`, bumping the locked `ws`
  to **8.21.0**. Both parent ranges already permitted it, so **no
  `package.json` change** was required.

After the bump, `npm audit` reports **0 vulnerabilities** across all 66
resolved packages.

## Vulnerability check

- `npm audit` **before**: 1 Moderate (`ws`). **After**: 0.
- `pip-audit` is N/A (Node project).
- No open GitHub Security advisories or Dependabot alerts on the repo.
- All direct deps (`discord.js 14.26.3`, `@discordjs/voice 0.19.2`,
  `@distube/ytdl-core 4.16.12`, `dotenv 16.6.1`, `opusscript 0.1.1`) and
  notable transitives (`undici 6.24.1` / `7.24.8`, `tough-cookie 5.1.2`,
  `lodash 4.18.1`) remain clean.

## Changes

- `package-lock.json` — `ws` 8.20.0 → 8.21.0 (lockfile only).
- `CHANGELOG.md` — new `Security` entry for the 2026-05-25 audit + fix.
- `README.md` — "Last manual CVE re-audit" date bumped to 2026-05-25.
- `package.json` unchanged (no direct dep is `ws`; ranges already permit
  the patched version).
- `.gitignore`, `SECURITY.md`, `setup.sh` reviewed — no edits needed.

## Test plan

- [x] `npm audit` on the patched lockfile → 0 vulnerabilities
- [x] `ws` resolves to 8.21.0 (within both `^8.19.0` and `^8.17.0`)
- [x] Only the lockfile `ws` entry changed (no unrelated churn)
- [ ] CodeQL workflow still passes on push

https://claude.ai/code/session_016tuiLgrvK7J2UPvWHrgsRY

---
_Generated by [Claude Code](https://claude.ai/code/session_016tuiLgrvK7J2UPvWHrgsRY)_