### PR TITLE
docs: 2026-06-01 dependency re-audit — clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-06-01 dependency re-audit — clean.** `npm audit` against the current
+  `package-lock.json` reported **0 vulnerabilities** across all 66 resolved
+  packages (Critical/High/Moderate/Low/Info). Manual GHSA / NVD cross-check
+  of every direct and notable transitive dep returned no new advisories in
+  the five days since the 2026-05-27 entry:
+  - `ws 8.21.0` — still clears GHSA-58qx-3vcg-4xpx (uninitialised memory
+    disclosure, Moderate; fixed 8.20.1).
+  - `undici 6.24.1` and `7.24.8` — still above the 6.24.0 / 7.24.0 fixes for
+    GHSA-4992-7rv2-5pvq (CRLF injection via `client.request()` `upgrade`
+    option), CVE-2026-22036 (unbounded decompression DoS), and CVE-2026-2581
+    (`DeduplicationHandler` unbounded memory consumption).
+  - `lodash 4.18.1` — still above the 4.18.0 fix for GHSA-r5fr-rjxr-66jc /
+    CVE-2026-4800 (`_.template` code injection via `options.imports` key
+    names, High).
+  - `tough-cookie 5.1.2` — no open advisories; historic CVE-2023-26136
+    prototype pollution did not affect `>=4.1.3`.
+  - Direct deps `discord.js 14.26.3`, `@discordjs/voice 0.19.2`,
+    `@distube/ytdl-core 4.16.12`, `dotenv 16.6.1`, `opusscript 0.1.1` — no
+    open advisories.
+  No GitHub Security advisories or Dependabot alerts open against the repo.
+  No code or dependency-version changes required.
 - **2026-05-27 dependency re-audit — clean.** `npm audit` against the current
   `package-lock.json` reported **0 vulnerabilities** across all 65 resolved
   packages (Critical/High/Moderate/Low/Info). A manual GHSA / NVD cross-check
@@ -86,7 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CHANGELOG.md` — this file.
 
 ### Changed
-- `README.md`: audit-date line bumped to **2026-05-27** to match the
+- `README.md`: audit-date line bumped to **2026-06-01** to match the
   latest re-audit entry above. Earlier change in this Unreleased block
   also added the `SECURITY.md` / `CHANGELOG.md` links and clarified
   that `./setup.sh` runs `npm audit` on every invocation.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Direct runtime deps (kept minimal):
 - [`opusscript`](https://www.npmjs.com/package/opusscript) (audio encoder)
 - [`dotenv`](https://www.npmjs.com/package/dotenv)
 
-Last manual CVE re-audit: **2026-05-27** — see [`CHANGELOG.md`](./CHANGELOG.md)
+Last manual CVE re-audit: **2026-06-01** — see [`CHANGELOG.md`](./CHANGELOG.md)
 for the audit notes. `npm audit` is also run automatically by `setup.sh`.
 
 ## Security


### PR DESCRIPTION
## Summary

CHANGELOG + README update recording a fresh dependency re-audit on 2026-06-01.

- `npm audit` against the current `package-lock.json` reports **0 vulnerabilities** across all 66 resolved packages.
- Manual GHSA / NVD cross-check across direct and notable transitive deps returned no new advisories in the five days since the 2026-05-27 entry.
- Confirmed still patched: `ws 8.21.0` (GHSA-58qx-3vcg-4xpx), `undici 6.24.1`/`7.24.8` (GHSA-4992-7rv2-5pvq, CVE-2026-22036, CVE-2026-2581), `lodash 4.18.1` (CVE-2026-4800).
- No GitHub Security advisories or Dependabot alerts open against the repo.

No code or dependency-version changes required — pure documentation:
- `CHANGELOG.md`: new 2026-06-01 entry
- `README.md`: audit-date line bumped 2026-05-27 → 2026-06-01

## Test plan

- [x] `package.json` / `package-lock.json` unchanged
- [x] Only `CHANGELOG.md` and `README.md` modified
- [x] No new advisory > 7.5 surfaced in the audit window

https://claude.ai/code/session_01Xps17HsNs18vZ9NdcDdn2B

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xps17HsNs18vZ9NdcDdn2B)_