### PR TITLE
docs: 2026-06-15 dependency re-audit — clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-06-15 dependency re-audit — clean.** `npm audit` against the current
+  `package-lock.json` reported **0 vulnerabilities** across all 65 resolved
+  packages (Critical/High/Moderate/Low/Info). Manual GHSA / NVD cross-check
+  of every direct and notable transitive dep returned no new advisories in
+  the two weeks since the 2026-06-01 entry:
+  - `ws 8.21.0` — still clears GHSA-58qx-3vcg-4xpx (uninitialised memory
+    disclosure, Moderate; fixed 8.20.1).
+  - `undici 6.24.1` and `7.24.8` — still above the 6.24.0 / 7.24.0 fixes for
+    GHSA-4992-7rv2-5pvq (CRLF injection via `client.request()` `upgrade`
+    option), CVE-2026-22036 (unbounded decompression DoS), and CVE-2026-2581
+    (`DeduplicationHandler` unbounded memory consumption).
+  - `lodash 4.18.1` — still above the 4.18.0 fix for GHSA-r5fr-rjxr-66jc /
+    CVE-2026-4800 (`_.template` code injection via `options.imports` key
+    names, High).
+  - `tough-cookie 5.1.2` — no open advisories.
+  - Direct deps `discord.js 14.26.3`, `@discordjs/voice 0.19.2`,
+    `@distube/ytdl-core 4.16.12`, `dotenv 16.6.1`, `opusscript 0.1.1` — no
+    open advisories.
+  No GitHub Security advisories or Dependabot alerts open against the repo.
+  No code or dependency-version changes required — pure documentation
+  refresh of the audit date in `README.md` and this entry.
 - **2026-06-01 dependency re-audit — clean.** `npm audit` against the current
   `package-lock.json` reported **0 vulnerabilities** across all 66 resolved
   packages (Critical/High/Moderate/Low/Info). Manual GHSA / NVD cross-check

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Direct runtime deps (kept minimal):
 - [`opusscript`](https://www.npmjs.com/package/opusscript) (audio encoder)
 - [`dotenv`](https://www.npmjs.com/package/dotenv)
 
-Last manual CVE re-audit: **2026-06-01** — see [`CHANGELOG.md`](./CHANGELOG.md)
+Last manual CVE re-audit: **2026-06-15** — see [`CHANGELOG.md`](./CHANGELOG.md)
 for the audit notes. `npm audit` is also run automatically by `setup.sh`.
 
 ## Security


### PR DESCRIPTION
## Summary

- `npm audit` against the current `package-lock.json` reports **0 vulnerabilities** across all 65 resolved packages (Critical / High / Moderate / Low / Info).
- Manual GHSA / NVD cross-check of every direct and notable transitive dep — `discord.js 14.26.3`, `@discordjs/voice 0.19.2`, `@distube/ytdl-core 4.16.12`, `dotenv 16.6.1`, `opusscript 0.1.1`, `ws 8.21.0`, `undici 6.24.1` + `7.24.8`, `tough-cookie 5.1.2`, `lodash 4.18.1` — returned **no new advisories** in the two weeks since the 2026-06-01 entry.
- No GitHub Security advisories or Dependabot alerts open against the repo.
- **No code or dependency-version changes** — pure documentation refresh.

## Changes

- `README.md` — audit date bumped `2026-06-01` → `2026-06-15`.
- `CHANGELOG.md` — new `2026-06-15 dependency re-audit — clean` entry under `[Unreleased] → Security`.

This is a docs-only PR and matches the auto-merge criterion for the routine (".md-only updates → auto-merge").

## Test plan

- [x] `npm audit` reports 0 vulnerabilities.
- [x] No `package.json` / `package-lock.json` changes.
- [ ] CI green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HbNbZec19G6wW5nKJX6UG8)_