### PR TITLE
fix(security): patch seven new undici advisories (2026-06-22 audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-06-22 dependency re-audit — seven new `undici` advisories fixed.**
+  `npm audit` against the current `package-lock.json` flagged seven new
+  advisories published 2026-06-16 → 2026-06-21 affecting both the `6.x`
+  (via `discord.js` / `@discordjs/rest`) and `7.x` (via
+  `@distube/ytdl-core`) branches resolved in the lockfile. The previous
+  re-audit on 2026-06-15 was clean, so all seven post-date that audit.
+  - **GHSA-vxpw-j846-p89q** — `undici` WebSocket client DoS via fragment
+    count bypass (**High, CVSS 7.5**). Affects `<6.27.0` and
+    `>=7.0.0 <7.28.0`. **Not reachable here:** the bot acts only as a
+    WebSocket *client* to Discord's gateway via `ws` (not `undici`'s
+    WebSocket client) and does not accept inbound WebSocket connections.
+  - **GHSA-hm92-r4w5-c3mj** — `undici` cross-origin request routing via
+    SOCKS5 proxy pool reuse (**High, CVSS 7.5**). Affects
+    `>=7.23.0 <7.28.0`. **Not reachable here:** the bot does not
+    configure `undici.SocksProxyAgent` and `@distube/ytdl-core` uses
+    `https-proxy-agent` (a separate package), not `undici`'s SOCKS5
+    proxy.
+  - **GHSA-vmh5-mc38-953g** — `undici` TLS certificate validation bypass
+    via dropped `requestTls` in SOCKS5 `ProxyAgent` (High, CVSS 7.4).
+    Affects `>=7.23.0 <7.28.0`. **Not reachable here:** same reason as
+    above — no SOCKS5 proxy configuration anywhere in the dependency
+    tree.
+  - **GHSA-pr7r-676h-xcf6** — `undici` cross-user information disclosure
+    via shared cache whitespace bypass (Moderate, CVSS 5.9). Affects
+    `>=7.0.0 <7.28.0`. **Not reachable here:** no shared `undici.Cache`
+    is configured by the bot or by `@distube/ytdl-core`.
+  - **GHSA-p88m-4jfj-68fv** — `undici` HTTP header injection via
+    `Set-Cookie` percent-decoding (Moderate, CVSS 5.9). Affects `<6.27.0`
+    and `>=7.0.0 <7.28.0`. Reachable in principle from `@distube/ytdl-core`
+    (which talks to YouTube via `undici`), but the bot never reflects
+    upstream response headers anywhere.
+  - **GHSA-35p6-xmwp-9g52** — `undici` HTTP response queue poisoning via
+    keep-alive socket reuse (Low, CVSS 3.7). Affects `<6.27.0` and
+    `>=7.0.0 <7.28.0`.
+  - **GHSA-g8m3-5g58-fq7m** — `undici` `Set-Cookie` `SameSite` attribute
+    downgrade via permissive substring matching (Low, CVSS 3.7). Affects
+    `<6.27.0` and `>=7.0.0 <7.28.0`.
+
+  All seven are fixed by `undici >= 6.27.0` (6.x branch) and
+  `undici >= 7.28.0` (7.x branch). Patched by adding scoped
+  `overrides` to `package.json`:
+  - `discord.js > undici` → `^6.27.0`
+  - `@discordjs/rest > undici` → `^6.27.0`
+  - `@distube/ytdl-core > undici` → `^7.28.0`
+
+  After regenerating the lockfile, `npm audit` reports **0
+  vulnerabilities** across all 48 resolved packages. The overrides are
+  scoped to specific parent packages so the 6.x branch (paired with the
+  Discord HTTP/gateway client) and 7.x branch (paired with ytdl-core)
+  stay isolated, matching the pre-bump topology. Smoke test: `discord.js`,
+  `@discordjs/voice`, and `@distube/ytdl-core` all `require()` cleanly,
+  `main.js` parses, and the resolved undici versions are 6.27.0 (both
+  6.x consumers) and 7.28.0 (ytdl-core).
+
+  Highest CVSS in this batch is 7.5, which does not exceed the >7.5
+  auto-merge threshold set for the dependency-audit routine, so this PR
+  is left for human review.
 - **2026-06-15 dependency re-audit — clean.** `npm audit` against the current
   `package-lock.json` reported **0 vulnerabilities** across all 65 resolved
   packages (Critical/High/Moderate/Low/Info). Manual GHSA / NVD cross-check

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Direct runtime deps (kept minimal):
 - [`opusscript`](https://www.npmjs.com/package/opusscript) (audio encoder)
 - [`dotenv`](https://www.npmjs.com/package/dotenv)
 
-Last manual CVE re-audit: **2026-06-15** — see [`CHANGELOG.md`](./CHANGELOG.md)
+Last manual CVE re-audit: **2026-06-22** — see [`CHANGELOG.md`](./CHANGELOG.md)
 for the audit notes. `npm audit` is also run automatically by `setup.sh`.
 
 ## Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@discordjs/rest/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -681,9 +681,9 @@
       }
     },
     "node_modules/discord.js/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -848,9 +848,9 @@
       "license": "0BSD"
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,17 @@
     "dotenv": "^16.6.1",
     "opusscript": "^0.1.1"
   },
+  "overrides": {
+    "discord.js": {
+      "undici": "^6.27.0"
+    },
+    "@discordjs/rest": {
+      "undici": "^6.27.0"
+    },
+    "@distube/ytdl-core": {
+      "undici": "^7.28.0"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/JakeWard98/Ky8er-Bot.git"


### PR DESCRIPTION
## Summary

`npm audit` against a fresh `node_modules` from the current `package-lock.json` flagged **seven new advisories** published 2026-06-16 → 2026-06-21, all affecting `undici` in two branches resolved by the lockfile: `6.x` (via `discord.js` / `@discordjs/rest`) and `7.x` (via `@distube/ytdl-core`). The 2026-06-15 re-audit was clean, so all seven post-date that audit.

Closed by adding scoped `overrides` to `package.json`:

```jsonc
"overrides": {
  "discord.js":          { "undici": "^6.27.0" },
  "@discordjs/rest":     { "undici": "^6.27.0" },
  "@distube/ytdl-core":  { "undici": "^7.28.0" }
}
```

After regenerating the lockfile, `npm audit` reports **0 vulnerabilities** across all 48 resolved packages.

## Advisories closed

| Advisory | Severity / CVSS | Affected | Reachable in this bot? |
|---|---|---|---|
| GHSA-vxpw-j846-p89q | **High, 7.5** | undici WebSocket *client* DoS via fragment count bypass | **No** — bot is only a WebSocket *client* to Discord's gateway via `ws` (not undici's WebSocket client), and never accepts inbound WebSocket connections. |
| GHSA-hm92-r4w5-c3mj | **High, 7.5** | undici cross-origin request routing via SOCKS5 pool reuse | **No** — no SOCKS5 proxy configured. `@distube/ytdl-core` uses `https-proxy-agent`, a separate package. |
| GHSA-vmh5-mc38-953g | High, 7.4 | undici TLS cert validation bypass via SOCKS5 `ProxyAgent` dropped `requestTls` | **No** — same reason, no SOCKS5. |
| GHSA-pr7r-676h-xcf6 | Moderate, 5.9 | undici cross-user info disclosure via shared cache whitespace | **No** — no shared `undici.Cache` configured. |
| GHSA-p88m-4jfj-68fv | Moderate, 5.9 | undici HTTP header injection via `Set-Cookie` percent-decoding | Reachable in principle from `@distube/ytdl-core` → YouTube, but the bot never reflects upstream response headers. |
| GHSA-35p6-xmwp-9g52 | Low, 3.7 | undici HTTP response queue poisoning via keep-alive socket reuse | Low practical impact. |
| GHSA-g8m3-5g58-fq7m | Low, 3.7 | undici `Set-Cookie` `SameSite` downgrade via permissive substring matching | Low practical impact. |

All seven are fixed by `undici >= 6.27.0` (6.x branch) and `undici >= 7.28.0` (7.x branch).

Highest CVSS in this batch is 7.5, which does **not** exceed the >7.5 auto-merge threshold set for the dependency-audit routine, so this PR is left for human review.

## Changes

- `package.json` — added scoped `overrides` block for `undici` under `discord.js`, `@discordjs/rest`, and `@distube/ytdl-core`.
- `package-lock.json` — regenerated; only the three `undici` versions changed (6.24.1 → 6.27.0 in both `discord.js`-tree paths, 7.24.8 → 7.28.0 at the root).
- `CHANGELOG.md` — new `2026-06-22 dependency re-audit` entry under `[Unreleased] → Security` documenting all seven CVEs, their CVSS scores, and per-advisory reachability analysis.
- `README.md` — audit date `2026-06-15` → `2026-06-22`.

## Verification

- `npm audit` after the bump: **found 0 vulnerabilities**.
- `npm ls undici --all`: resolves `undici@6.27.0` under both `discord.js` paths and `undici@7.28.0` at the root.
- Smoke test: `require('discord.js')`, `require('@discordjs/voice')`, `require('@distube/ytdl-core')` all load; `node -c main.js` parses clean.

## Test plan

- [ ] `npm install && npm audit` reports 0 vulnerabilities.
- [ ] `npm start` boots and connects to the gateway.
- [ ] `^join` / `^play <url>` / `^dc` happy-path still works (ytdl-core under undici 7.28.0).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NguQH6kajq3wLc2cnzcMJ2)_