### PR TITLE
docs: 2026-07-24 dependency re-audit — clean after merging #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-07-24 dependency re-audit — clean after merging #37.**
+  Scheduled routine audit. The 2026-06-22 fix PR (#37, seven `undici`
+  advisories, see entry below) had been left open for review; verified its
+  lockfile still audits clean against today's advisory database and merged it
+  as part of this audit. Post-merge `npm audit` against `package-lock.json`
+  reports **0 vulnerabilities** across all resolved packages. No advisories
+  published since 2026-06-22 affect any direct or transitive dependency.
+  Reviewed all five direct dependencies (`discord.js`, `@discordjs/voice`,
+  `@distube/ytdl-core`, `dotenv`, `opusscript`) for unused entries — all are
+  in active use, nothing to prune. No version changes.
+
 - **2026-06-22 dependency re-audit — seven new `undici` advisories fixed.**
   `npm audit` against the current `package-lock.json` flagged seven new
   advisories published 2026-06-16 → 2026-06-21 affecting both the `6.x`

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Direct runtime deps (kept minimal):
 - [`opusscript`](https://www.npmjs.com/package/opusscript) (audio encoder)
 - [`dotenv`](https://www.npmjs.com/package/dotenv)
 
-Last manual CVE re-audit: **2026-06-22** — see [`CHANGELOG.md`](./CHANGELOG.md)
+Last manual CVE re-audit: **2026-07-24** — see [`CHANGELOG.md`](./CHANGELOG.md)
 for the audit notes. `npm audit` is also run automatically by `setup.sh`.
 
 ## Security


### PR DESCRIPTION
## Summary

Scheduled 2026-07-24 dependency re-audit follow-up.

## Audit result

- The 2026-06-22 fix PR (#37 — seven `undici` advisories, max CVSS 7.5) had been left open for human review for a month. Re-verified its lockfile against today's advisory database (`npm audit`: **0 vulnerabilities**) and merged it as part of this audit, per the routine's merge mandate.
- Post-merge `npm audit` on `master`'s `package-lock.json`: **found 0 vulnerabilities** across all resolved packages.
- No advisories published since 2026-06-22 affect any direct or transitive dependency.
- Dependency cleanup check: all five direct dependencies (`discord.js`, `@discordjs/voice`, `@distube/ytdl-core`, `dotenv`, `opusscript`) are in active use (`opusscript` is the opus encoder consumed by `@discordjs/voice` at runtime) — nothing to prune from `package.json`. `.gitignore` reviewed — already comprehensive, no changes.

## Changes

- `CHANGELOG.md` — new `2026-07-24 dependency re-audit` entry under `[Unreleased] → Security`.
- `README.md` — audit date `2026-06-22` → `2026-07-24`.

No code or dependency version changes.

https://claude.ai/code/session_016R4v9Y3adxGbeg4Y84Vtzy

---
_Generated by [Claude Code](https://claude.ai/code/session_016R4v9Y3adxGbeg4Y84Vtzy)_