### PR TITLE
chore(deps): 2026-08-05 re-audit (clean) + in-range lockfile refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-08-05 dependency re-audit — clean, no new advisories; lockfile
+  refreshed in-range.**
+  Scheduled routine audit. `npm audit` against `package-lock.json` reports
+  **0 vulnerabilities**, and a manual cross-check via the npm bulk-advisory
+  endpoint over all 59 resolved packages returned 0 advisories — both before
+  and after the in-range lockfile refresh (`@types/node → 26.1.2`,
+  `discord-api-types → 0.38.52`, `ws → 8.21.2`,
+  `@napi-rs/wasm-runtime → 1.2.2`). A web sweep found no advisory published
+  since the 2026-07-27 re-audit affecting any package in the tree; the
+  June-2026 `undici` advisory set remains closed by the pinned
+  `6.27.0` / `7.28.0+` overrides. All five direct dependencies
+  (`discord.js`, `@discordjs/voice`, `@distube/ytdl-core`, `dotenv`,
+  `opusscript`) remain in active use — nothing to prune. No open Dependabot
+  alerts, security PRs, or issues on the repository. Nothing to patch.
+
 - **2026-07-27 dependency re-audit — clean, no new advisories; lockfile
   refreshed in-range.**
   Scheduled routine audit. `npm audit` against `package-lock.json` reports

--- a/package-lock.json
+++ b/package-lock.json
@@ -268,21 +268,24 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
-      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@sapphire/async-queue": {
@@ -581,9 +584,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -635,9 +638,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.51",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.51.tgz",
-      "integrity": "sha512-SnaFHd+b8Z3HgjEIoSA1wkstXCt6J0Zrxvny0BJZZz7AhmFSetRY3DMrIdO3LFDMeeTxF7WKornnAGxaws5Adw==",
+      "version": "0.38.52",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.52.tgz",
+      "integrity": "sha512-uwe9EKfbjsmgWc2fdFjvDbj+dQqx3lp7wqDCmIha0jInuU+xeQjkCK9tMMn+p7RXfdVQORCInq4cD3U2ymDmyg==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"
@@ -862,9 +865,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.21.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary

Scheduled 2026-08-05 dependency security re-audit — **clean, nothing to patch**.

### Audit results
- `npm audit` against `package-lock.json`: **0 vulnerabilities** — verified both before and after the lockfile refresh below.
- Manual cross-check via the npm bulk-advisory endpoint over all 59 resolved packages: **0 advisories**.
- Web sweep: no advisory published since the 2026-07-27 re-audit affects any package in the tree; the June-2026 `undici` advisory set remains closed by the pinned `6.27.0` / `7.28.0+` overrides.
- No open Dependabot alerts, security PRs, or issues on the repository.
- No advisory of any severity observed this run, so nothing meets the >7.5 immediate-patch bar.

### Changes
- **`package-lock.json`**: in-range refresh — `@types/node → 26.1.2`, `discord-api-types → 0.38.52`, `ws → 8.21.2`, `@napi-rs/wasm-runtime → 1.2.2`. No direct-dependency or override changes; audits clean after refresh.
- **`CHANGELOG.md`**: 2026-08-05 audit entry.
- Dependency cleanup review: all five direct dependencies (`discord.js`, `@discordjs/voice`, `@distube/ytdl-core`, `dotenv`, `opusscript`) verified in active use — nothing to prune. `.gitignore` and `*.md` docs reviewed, no updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ACnHbSV3APiy44xmF7xmGZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACnHbSV3APiy44xmF7xmGZ)_