### PR TITLE
chore(deps): 2026-08-10 security re-audit (clean) + in-range lockfile refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-08-10 dependency re-audit — clean; August undici advisory set
+  confirmed closed; lockfile refreshed in-range.**
+  Scheduled routine audit. `npm audit` against `package-lock.json` reports
+  **0 vulnerabilities** — both before and after the in-range lockfile refresh
+  (`@types/node → 26.2.0`, `discord-api-types → 0.38.53`, `ws → 8.21.3`).
+  A GitHub Advisory Database sweep found a new `undici` advisory batch
+  published 2026-08-03 — notably GHSA-4cwx-7wf7-3272 / CVE-2026-13697
+  (High, CVSS 7.4: cache-interceptor shared-cache info disclosure +
+  parse-time crash on malformed `Cache-Control: private` directives,
+  affecting `>=7.0.0 <7.29.0` and `>=8.0.0 <8.9.0`) plus four Moderate
+  advisories. **Already closed in this tree**: the lockfile resolves
+  `undici 7.29.0` (the patched version) for `@distube/ytdl-core`, and the
+  `discord.js` / `@discordjs/rest` copies resolve `6.28.0`, which is outside
+  every affected range (confirmed by the clean `npm audit`). No other new
+  advisory affects any package in the tree. All five direct dependencies
+  remain in active use — nothing to prune; `dotenv 17.x` and `undici 8.x`
+  majors deliberately not taken (out of range, no security need). No open
+  pull requests or issues on the repository. Nothing left to patch; no
+  unpatched advisory ≥ 7.5 CVSS (or any severity) in the resolved tree.
+
 - **2026-08-05 dependency re-audit — clean, no new advisories; lockfile
   refreshed in-range.**
   Scheduled routine audit. `npm audit` against `package-lock.json` reports

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Direct runtime deps (kept minimal):
 - [`opusscript`](https://www.npmjs.com/package/opusscript) (audio encoder)
 - [`dotenv`](https://www.npmjs.com/package/dotenv)
 
-Last manual CVE re-audit: **2026-07-27** — see [`CHANGELOG.md`](./CHANGELOG.md)
+Last manual CVE re-audit: **2026-08-10** — see [`CHANGELOG.md`](./CHANGELOG.md)
 for the audit notes. `npm audit` is also run automatically by `setup.sh`.
 
 ## Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -584,9 +584,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -638,9 +638,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.52",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.52.tgz",
-      "integrity": "sha512-uwe9EKfbjsmgWc2fdFjvDbj+dQqx3lp7wqDCmIha0jInuU+xeQjkCK9tMMn+p7RXfdVQORCInq4cD3U2ymDmyg==",
+      "version": "0.38.53",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.53.tgz",
+      "integrity": "sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"
@@ -865,9 +865,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.21.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
-      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary

Scheduled 2026-08-10 dependency security re-audit. **Result: clean — `npm audit` reports 0 vulnerabilities, and the new August undici advisory batch is confirmed already closed in this tree.**

### Audit performed
- `npm audit` against `package-lock.json`: **0 vulnerabilities** — both before and after the in-range refresh below.
- GitHub Advisory Database sweep found a new `undici` advisory batch published 2026-08-03 — notably **GHSA-4cwx-7wf7-3272 / CVE-2026-13697 (High, CVSS 7.4)**: cache-interceptor shared-cache info disclosure + parse-time crash, affecting `>=7.0.0 <7.29.0` and `>=8.0.0 <8.9.0` — plus four Moderate advisories. **Already closed here**: the lockfile resolves `undici 7.29.0` (the patched version) for `@distube/ytdl-core`, and the nested `discord.js` / `@discordjs/rest` copies resolve `6.28.0`, outside every affected range (confirmed by the clean `npm audit`).
- All five direct dependencies remain in active use — nothing to prune. `dotenv 17.x` / `undici 8.x` majors deliberately not taken (out of semver range, no security need). No open PRs or issues on the repository.

### Changes
- `package-lock.json`: in-range refresh — `@types/node → 26.2.0`, `discord-api-types → 0.38.53`, `ws → 8.21.3`.
- `CHANGELOG.md`: audit notes.
- `README.md`: last-audit date `2026-07-27 → 2026-08-10` (was stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rPaBFnoMWomcTqnwwckJY

---
_Generated by [Claude Code](https://claude.ai/code/session_016rPaBFnoMWomcTqnwwckJY)_