### PR TITLE
chore(audit): 2026-08-17 security re-audit (clean) — changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **2026-08-17 dependency re-audit — clean, no new advisories; lockfile
+  already current in-range.**
+  Scheduled routine audit. `npm audit` against `package-lock.json` reports
+  **0 vulnerabilities** across all 65 resolved packages, and an in-range
+  `npm install --package-lock-only` refresh produced no changes — the tree
+  is already at the newest in-range versions (`discord.js 14.27.0`,
+  `undici 7.29.0` for `@distube/ytdl-core`, `undici 6.28.0` for
+  `discord.js` / `@discordjs/rest`). A GitHub Advisory Database / web sweep
+  found no advisory affecting any package in the tree published since the
+  2026-08-10 re-audit; the August `undici` batch — notably
+  GHSA-4cwx-7wf7-3272 (High, CVSS 7.4, cache-interceptor disclosure/crash,
+  affecting `>=7.0.0 <7.29.0` and `>=8.0.0 <8.9.0`) — remains closed by the
+  resolved `7.29.0` / out-of-range `6.28.0` copies. All five direct
+  dependencies remain in active use — nothing to prune; the `dotenv 17.x`
+  major deliberately not taken (out of range, no security need). No open
+  pull requests or issues on the repository. Nothing to patch; no unpatched
+  advisory ≥ 7.5 CVSS (or any severity) in the resolved tree. (Note: the
+  Dependabot alerts API was not reachable from this run's environment;
+  coverage came from `npm audit` — which mirrors the GitHub Advisory
+  Database — plus the web sweep.)
+
 - **2026-08-10 dependency re-audit — clean; August undici advisory set
   confirmed closed; lockfile refreshed in-range.**
   Scheduled routine audit. `npm audit` against `package-lock.json` reports


### PR DESCRIPTION
## Summary
Scheduled 2026-08-17 security re-audit of the dependency tree — **clean, nothing to patch, no dependency changes needed**.

- `npm audit` against `package-lock.json`: **0 vulnerabilities** across all 65 resolved packages.
- In-range `npm install --package-lock-only` refresh produced no changes — the tree is already at the newest in-range versions (`discord.js 14.27.0`, `undici 7.29.0` for `@distube/ytdl-core`, `undici 6.28.0` for `discord.js`/`@discordjs/rest`).
- Advisory sweep: nothing new affecting the tree since the 2026-08-10 re-audit. The August undici batch — notably GHSA-4cwx-7wf7-3272 (High, CVSS 7.4) — remains closed: the affected ranges are `>=7.0.0 <7.29.0` / `>=8.0.0 <8.9.0`, and this tree resolves `7.29.0` (patched) and `6.28.0` (outside the ranges).
- No open Dependabot PRs or issues. All five direct dependencies in active use; `dotenv 17.x` major deliberately not taken (out of range, no security need). `.gitignore` and docs reviewed — no updates needed beyond the changelog.

## Changes
- `CHANGELOG.md` — audit log entry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSsgDDmfGJp1Jdgw7jZ6N1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSsgDDmfGJp1Jdgw7jZ6N1)_